### PR TITLE
デモ走行中にGPS更新が地図ビューを上書きする問題を修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -418,7 +418,7 @@ let selectedMode='driving';
 let gpsMarker=null,gpsAccCircle=null,watchId=null,isTracking=false,gpsLatLng=null;
 let useGpsAsStart=false;
 // デモ
-let demoCoords=[],demoIdx=0,demoRafId=null,demoPaused=true,demoSpeed=1;
+let demoCoords=[],demoIdx=0,demoRafId=null,demoPaused=true,demoSpeed=1,isDemoActive=false;
 let demoMarker=null,demoTrail=null,lastDemoTs=null,demoSteps=[];
 let demoMilestone25=false,demoMilestone50=false,demoMilestone75=false; // デモ進捗マイルストーンフラグ
 let stepMarkers=[];  // 地図上のステップ番号マーカー
@@ -872,6 +872,8 @@ let naviFirstGps = false;
 
 // GPS更新 → 案内ロジック
 function onNaviGps(pos){
+	// デモ走行中はGPS更新を無視する
+	if(isDemoActive){console.log('[onNaviGps] デモ走行中のためGPS更新をスキップ');return;}
 	const lat=pos.coords.latitude,lng=pos.coords.longitude;
 	const acc=pos.coords.accuracy;
 	const curPos=[lat,lng];
@@ -1147,6 +1149,7 @@ function startDemo(){
 	if(demoCoords.length<2){console.warn('[startDemo] ルート座標が不足しているためデモ開始不可');return;}
 	console.log(`[startDemo] デモ走行開始: ${demoCoords.length} 座標点 速度${demoSpeed}×`);
 	stopDemo();stopNavi();
+	isDemoActive=true;
 	// 案内状態を初期化
 	naviActive=true;naviSpoken={};naviCurrentStepIdx=0;naviApproaching=false;naviPrevDist=Infinity;naviMuted=false;
 	document.getElementById('navi-mute-btn').textContent='🔊';
@@ -1233,6 +1236,7 @@ function pauseDemo(){console.log('[pauseDemo] デモ一時停止');demoPaused=tr
 function resumeDemo(){console.log('[resumeDemo] デモ再開');demoPaused=false;lastDemoTs=null;document.getElementById('demo-play-btn').textContent='⏸';demoRafId=requestAnimationFrame(demoTick);}
 function stopDemo(){
 	console.log('[stopDemo] デモ走行停止');
+	isDemoActive=false;
 	pauseDemo();naviActive=false;demoIdx=0;
 	demoMilestone25=false;demoMilestone50=false;demoMilestone75=false;
 	if(demoMarker){map.removeLayer(demoMarker);demoMarker=null;}


### PR DESCRIPTION
## 概要

closes #29

デモ走行中に `onNaviGps()` がGPS位置で `map.setView()` を呼び出し、地図ビューをリアルGPS位置に上書きし続けることで、デモ自車マーカーが画面外に追いやられ移動していないように見える問題を修正。

## 変更内容

- `isDemoActive` フラグを追加（デモ走行中は `true`）
- `startDemo()` で `isDemoActive=true` を設定
- `stopDemo()` で `isDemoActive=false` を設定
- `onNaviGps()` の先頭に `if(isDemoActive)return` のガードを追加

## テスト結果

### 自動テスト（全項目OK）
- JS構文エラー：なし
- 必須関数：全て存在
- タブインデント規約：準拠
- `isDemoActive` が `startDemo()`・`stopDemo()` 両方で設定：OK
- `onNaviGps()` 先頭のガード：OK
- console.log/error/warn：実装済み
- catchブロックのログ：全件OK
- ライブラリバージョン固定：OK
- 有料ライブラリ不使用：OK
- Nominatim User-Agent：設定済み

### 手動テスト（マージ後にユーザーが実施）
- デモ走行で自車がルートの最後まで移動するか確認