### PR TITLE
デモ走行で自車が移動しない問題を修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -1147,8 +1147,9 @@ document.getElementById('navi-mute-btn').addEventListener('click',()=>{
 // ════════════════════════════════════════════════
 const BASE_SPD=60;
 function startDemo(){
-	if(demoCoords.length<2){console.warn('[startDemo] ルート座標が不足しているためデモ開始不可');return;}
+	if(demoCoords.length<2){console.warn('[startDemo] ルート座標が不足しているためデモ開始不可');logDebug('[startDemo] 座標不足のため開始不可');return;}
 	console.log(`[startDemo] デモ走行開始: ${demoCoords.length} 座標点 速度${demoSpeed}×`);
+	logDebug(`[startDemo] 開始 座標数:${demoCoords.length}`);
 	stopDemo();stopNavi();
 	isDemoActive=true;
 	// 案内状態を初期化
@@ -1169,13 +1170,15 @@ function startDemo(){
 	demoMarker=L.marker(demoCoords[0],{icon:carIcon,zIndexOffset:1000}).addTo(map);
 	demoTrail=L.polyline([demoCoords[0]],{color:'#f5c518',weight:3,opacity:.7}).addTo(map);
 	document.getElementById('demo-play-btn').textContent='⏸';
-	goToMap();setTimeout(()=>map.setView(demoCoords[0],16),100);
+	goToMap();setTimeout(()=>map.setView(demoCoords[0],16,{animate:false}),100);
 	speak(makeVoiceText('depart','','','',null));
 	// デモ開始位置がルート先頭でない場合に備えてシーク
 	seekNearestStep(demoCoords[0]);
 	updateNaviBanner(naviCurrentStepIdx,null);
 	highlightNaviStep(naviCurrentStepIdx);
+	logDebug('[startDemo] RAF 登録直前');
 	demoRafId=requestAnimationFrame(demoTick);
+	logDebug('[startDemo] RAF 登録完了 → demoTick 待機中');
 }
 function demoTick(ts){
 	if(demoPaused||demoIdx>=demoCoords.length-1)return;
@@ -1212,9 +1215,9 @@ function demoTick(ts){
 
 		// 進捗マイルストーンログ（25/50/75/100%）
 		const prog=demoCoords.length>1?(demoIdx/(demoCoords.length-1))*100:0;
-		if(prog>=25&&prog<26&&!demoMilestone25){demoMilestone25=true;console.log('[demoTick] 進捗 25%');}
-		if(prog>=50&&prog<51&&!demoMilestone50){demoMilestone50=true;console.log('[demoTick] 進捗 50%');}
-		if(prog>=75&&prog<76&&!demoMilestone75){demoMilestone75=true;console.log('[demoTick] 進捗 75%');}
+		if(prog>=25&&prog<26&&!demoMilestone25){demoMilestone25=true;console.log('[demoTick] 進捗 25%');logDebug('[demoTick] 進捗 25%');}
+		if(prog>=50&&prog<51&&!demoMilestone50){demoMilestone50=true;console.log('[demoTick] 進捗 50%');logDebug('[demoTick] 進捗 50%');}
+		if(prog>=75&&prog<76&&!demoMilestone75){demoMilestone75=true;console.log('[demoTick] 進捗 75%');logDebug('[demoTick] 進捗 75%');}
 
 		if(demoIdx>=demoCoords.length-1){
 			const last=demoCoords[demoCoords.length-1];
@@ -1222,6 +1225,7 @@ function demoTick(ts){
 			document.getElementById('demo-play-btn').textContent='▶';
 			document.getElementById('demo-progress-bar').style.width='100%';
 			console.log('[demoTick] デモ走行 100% 完了');
+			logDebug('[demoTick] デモ走行 100% 完了');
 			speak(makeVoiceText('arrive','','','',null));
 			showStatus('🏁 デモ走行が完了しました','info');
 			naviActive=false;return;
@@ -1229,6 +1233,7 @@ function demoTick(ts){
 	}catch(e){
 		// 例外が発生しても RAF ループを継続し、ログに記録する
 		console.error(`[demoTick] 例外発生（ループ継続）: ${e.message}`,e);
+		logError(`[demoTick] 例外: ${e.message}`);
 	}
 	demoRafId=requestAnimationFrame(demoTick);
 }
@@ -1333,6 +1338,11 @@ function logVoice(text){
 }
 function logError(msg){
 	const e=makeEntry('err',`エラー: ${msg}`,()=>`<div class="log-raw">${escHtml(msg)}</div>`);
+	prependToPane('pane-all',e);
+}
+// デバッグ用ログ（アプリ内ログパネルに出力）
+function logDebug(msg){
+	const e=makeEntry('info',msg,()=>`<div class="log-raw">${escHtml(msg)}</div>`);
 	prependToPane('pane-all',e);
 }
 function logRouteResponse(data){

--- a/index.html
+++ b/index.html
@@ -1051,6 +1051,7 @@ function highlightNaviStep(naviIdx){
 	let markerPos=0;
 	demoSteps.forEach(({naviIdx:ni,num},i)=>{
 		const s=naviSteps[ni];
+		if(!s)return;// naviSteps との同期ズレを防ぐ
 		if(s.type==='depart'||s.type==='notification')return;
 		const m=stepMarkers[markerPos++];
 		if(!m)return;
@@ -1178,51 +1179,56 @@ function startDemo(){
 }
 function demoTick(ts){
 	if(demoPaused||demoIdx>=demoCoords.length-1)return;
-	if(!lastDemoTs)lastDemoTs=ts;
-	const dt=Math.min((ts-lastDemoTs)/1000,.1);lastDemoTs=ts;
-	let remain=BASE_SPD*demoSpeed*dt;
-	let curPos=null;
+	try{
+		if(!lastDemoTs)lastDemoTs=ts;
+		const dt=Math.min((ts-lastDemoTs)/1000,.1);lastDemoTs=ts;
+		let remain=BASE_SPD*demoSpeed*dt;
+		let curPos=null;
 
-	while(remain>0&&demoIdx<demoCoords.length-1){
-		const a=demoCoords[demoIdx],b=demoCoords[demoIdx+1];
-		const seg=haversine(a,b);
-		if(remain>=seg){
-			// セグメントを丸ごと通過 → 終点を現在位置として記録
-			remain-=seg;
-			demoIdx++;
-			curPos=demoCoords[demoIdx];
-		}else{
-			// セグメント途中 → 補間して現在位置を計算
-			const t=remain/seg;
-			curPos=[a[0]+(b[0]-a[0])*t, a[1]+(b[1]-a[1])*t];
-			remain=0;
+		while(remain>0&&demoIdx<demoCoords.length-1){
+			const a=demoCoords[demoIdx],b=demoCoords[demoIdx+1];
+			const seg=haversine(a,b);
+			if(remain>=seg){
+				// セグメントを丸ごと通過 → 終点を現在位置として記録
+				remain-=seg;
+				demoIdx++;
+				curPos=demoCoords[demoIdx];
+			}else{
+				// セグメント途中 → 補間して現在位置を計算
+				const t=remain/seg;
+				curPos=[a[0]+(b[0]-a[0])*t, a[1]+(b[1]-a[1])*t];
+				remain=0;
+			}
 		}
-	}
 
-	// フレームごとに1回だけマーカー更新・地図追従・案内チェック
-	if(curPos){
-		demoMarker.setLatLng(curPos);
-		demoTrail.addLatLng(curPos);
-		map.setView(curPos,map.getZoom());
-		updateDemoProg();
-		if(naviActive)checkAndSpeak(curPos);
-	}
+		// フレームごとに1回だけマーカー更新・地図追従・案内チェック
+		if(curPos){
+			demoMarker.setLatLng(curPos);
+			demoTrail.addLatLng(curPos);
+			map.setView(curPos,map.getZoom(),{animate:false});// アニメーションなしで即時追従
+			updateDemoProg();
+			if(naviActive)checkAndSpeak(curPos);
+		}
 
-	// 進捗マイルストーンログ（25/50/75/100%）
-	const prog=demoCoords.length>1?(demoIdx/(demoCoords.length-1))*100:0;
-	if(prog>=25&&prog<26&&!demoMilestone25){demoMilestone25=true;console.log('[demoTick] 進捗 25%');}
-	if(prog>=50&&prog<51&&!demoMilestone50){demoMilestone50=true;console.log('[demoTick] 進捗 50%');}
-	if(prog>=75&&prog<76&&!demoMilestone75){demoMilestone75=true;console.log('[demoTick] 進捗 75%');}
+		// 進捗マイルストーンログ（25/50/75/100%）
+		const prog=demoCoords.length>1?(demoIdx/(demoCoords.length-1))*100:0;
+		if(prog>=25&&prog<26&&!demoMilestone25){demoMilestone25=true;console.log('[demoTick] 進捗 25%');}
+		if(prog>=50&&prog<51&&!demoMilestone50){demoMilestone50=true;console.log('[demoTick] 進捗 50%');}
+		if(prog>=75&&prog<76&&!demoMilestone75){demoMilestone75=true;console.log('[demoTick] 進捗 75%');}
 
-	if(demoIdx>=demoCoords.length-1){
-		const last=demoCoords[demoCoords.length-1];
-		demoMarker.setLatLng(last);
-		document.getElementById('demo-play-btn').textContent='▶';
-		document.getElementById('demo-progress-bar').style.width='100%';
-		console.log('[demoTick] デモ走行 100% 完了');
-		speak(makeVoiceText('arrive','','','',null));
-		showStatus('🏁 デモ走行が完了しました','info');
-		naviActive=false;return;
+		if(demoIdx>=demoCoords.length-1){
+			const last=demoCoords[demoCoords.length-1];
+			demoMarker.setLatLng(last);
+			document.getElementById('demo-play-btn').textContent='▶';
+			document.getElementById('demo-progress-bar').style.width='100%';
+			console.log('[demoTick] デモ走行 100% 完了');
+			speak(makeVoiceText('arrive','','','',null));
+			showStatus('🏁 デモ走行が完了しました','info');
+			naviActive=false;return;
+		}
+	}catch(e){
+		// 例外が発生しても RAF ループを継続し、ログに記録する
+		console.error(`[demoTick] 例外発生（ループ継続）: ${e.message}`,e);
 	}
 	demoRafId=requestAnimationFrame(demoTick);
 }


### PR DESCRIPTION
Closes #31

## 変更内容

### バグ修正

- **`demoTick` に try-catch を追加**  
  RAF コールバック内で例外が発生するとループが無音で停止していた。try-catch で例外を捕捉しログに記録しつつ、ループを継続するよう修正。

- **`map.setView` に `{animate:false}` を追加**  
  `demoTick` 内で 60fps ごとに Leaflet のアニメーションが生成され干渉していた。`demoTick` 内と `startDemo` の `setTimeout` 内の両方に `{animate:false}` を追加。

- **`highlightNaviStep` に null ガードを追加**  
  `naviSteps[ni]` が undefined の場合に `s.type` で TypeError が発生し、`startDemo()` 内の `requestAnimationFrame(demoTick)` に到達できないケースがあった。`if(!s)return;` を追加して対処。

### デバッグ支援

- **`logDebug()` 関数を追加**  
  Android Chrome ではコンソールログが確認できないため、デモ走行の主要イベント（開始・RAF登録・進捗25/50/75/100%・例外）をアプリ内ログパネルに出力するようにした。

## 手動テスト項目

- [ ] ルートを検索してデモ走行を開始し、自車がルートに沿って移動するか
- [ ] デモ走行中に一時停止・再開が正常に動作するか
- [ ] デモ停止後に再びデモ開始して正常に動作するか
- [ ] アプリ内ログに `[startDemo] RAF 登録完了` が表示されるか
- [ ] デモ完了時に `[demoTick] デモ走行 100% 完了` がログに表示されるか