### PR TITLE
デモ走行で自車が視覚的に動かない問題を修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -397,7 +397,7 @@ input[type="text"]:disabled{opacity:.4;cursor:not-allowed;}
 // ════════════════════════════════════════════════
 //  アプリバージョン
 // ════════════════════════════════════════════════
-const APP_VERSION='260411PR34';
+const APP_VERSION='260412PR35';
 document.getElementById('app-version').textContent=APP_VERSION;
 console.log(`[App] バージョン: ${APP_VERSION}`);
 
@@ -1179,7 +1179,8 @@ function startDemo(){
 	demoMarker=L.marker(demoCoords[0],{icon:carIcon,zIndexOffset:1000}).addTo(map);
 	demoTrail=L.polyline([demoCoords[0]],{color:'#f5c518',weight:3,opacity:.7}).addTo(map);
 	document.getElementById('demo-play-btn').textContent='⏸';
-	goToMap();setTimeout(()=>map.setView(demoCoords[0],16,{animate:false}),100);
+	// ルート全体が見えるように fitBounds → 車がルート上を移動するのが視覚的にわかる
+	goToMap();setTimeout(()=>map.fitBounds(L.latLngBounds(demoCoords),{padding:[40,40],animate:false}),100);
 	speak(makeVoiceText('depart','','','',null));
 	// デモ開始位置がルート先頭でない場合に備えてシーク
 	seekNearestStep(demoCoords[0]);
@@ -1213,11 +1214,11 @@ function demoTick(ts){
 			}
 		}
 
-		// フレームごとに1回だけマーカー更新・地図追従・案内チェック
+		// フレームごとに1回だけマーカー更新・案内チェック
+		// ※ map.setView は呼ばない → 地図が車を追わず、車がルート上を視覚的に移動する
 		if(curPos){
 			demoMarker.setLatLng(curPos);
 			demoTrail.addLatLng(curPos);
-			map.setView(curPos,map.getZoom(),{animate:false});// アニメーションなしで即時追従
 			updateDemoProg();
 			if(naviActive)checkAndSpeak(curPos);
 		}


### PR DESCRIPTION
## 概要

デモ走行で自車マーカーが「静止しているように見える」問題を修正する。

## 根本原因

`demoTick()` 内で `map.setView(curPos, map.getZoom())` を毎フレーム（60fps）呼んでいたため、地図が常に自車を中央に追従していた。自車は実際には移動しているが、地図が追いかけるため、ユーザーには車が静止しているように見えていた。

> VOICEログ（「左折してください」「250m先、右折」）が RAF 登録後に出力されていたことから、`demoTick` は正常に動作していた。

## 修正内容

| 変更箇所 | 変更前 | 変更後 |
|---------|--------|--------|
| `demoTick`（マーカー更新後） | `map.setView(curPos, map.getZoom(), {animate:false})` を毎フレーム呼ぶ | 削除（地図追従なし） |
| `startDemo`（初期ビュー） | `map.setView(demoCoords[0], 16, {animate:false})` | `map.fitBounds(L.latLngBounds(demoCoords), {padding:[40,40], animate:false})` |
| `APP_VERSION` | `260411PR34` | `260412PR35` |

## 変更後の動作

- デモ開始時にルート全体が地図に表示される
- 自車マーカーがルート上を視覚的に移動する（地図は動かず、マーカーが移動）

## テスト

### 自動テスト（実施済み）
- [x] JS 構文エラーなし
- [x] 必須 DOM 要素すべて存在
- [x] 必須関数すべて実装済み
- [x] タブインデント規約準拠（スペースインデント 0 行）
- [x] `console.log` / `console.error` / `console.warn` 実装あり
- [x] 全 `catch` ブロックに `console.error` / `console.warn` あり
- [x] 外部ライブラリバージョン固定（Leaflet 1.9.4）
- [x] Nominatim `User-Agent` 設定あり

### 手動テスト（マージ後にユーザーが確認）
- [ ] ルート検索 → デモボタン押下でルート全体が地図に表示されるか
- [ ] 自車マーカーがルート上を移動しているのが視覚的に確認できるか
- [ ] デモ完了時に「🏁 デモ走行が完了しました」が表示されるか