### PR TITLE
デモ走行の低速化・前後バウンス問題を修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -397,7 +397,7 @@ input[type="text"]:disabled{opacity:.4;cursor:not-allowed;}
 // ════════════════════════════════════════════════
 //  アプリバージョン
 // ════════════════════════════════════════════════
-const APP_VERSION='260412PR35';
+const APP_VERSION='260412PR36';
 document.getElementById('app-version').textContent=APP_VERSION;
 console.log(`[App] バージョン: ${APP_VERSION}`);
 
@@ -1175,20 +1175,25 @@ function startDemo(){
 	demoMilestone25=false;demoMilestone50=false;demoMilestone75=false;
 	document.getElementById('demo-progress-bar').style.width='0%';
 	if(demoMarker)map.removeLayer(demoMarker);
-	if(demoTrail)map.removeLayer(demoTrail);
+	if(demoTrail){map.removeLayer(demoTrail);demoTrail=null;}
 	demoMarker=L.marker(demoCoords[0],{icon:carIcon,zIndexOffset:1000}).addTo(map);
-	demoTrail=L.polyline([demoCoords[0]],{color:'#f5c518',weight:3,opacity:.7}).addTo(map);
+	// demoTrail（軌跡ポリライン）は廃止：毎フレームのSVG再描画がRAFを著しく低速化するため
 	document.getElementById('demo-play-btn').textContent='⏸';
-	// ルート全体が見えるように fitBounds → 車がルート上を移動するのが視覚的にわかる
-	goToMap();setTimeout(()=>map.fitBounds(L.latLngBounds(demoCoords),{padding:[40,40],animate:false}),100);
 	speak(makeVoiceText('depart','','','',null));
 	// デモ開始位置がルート先頭でない場合に備えてシーク
 	seekNearestStep(demoCoords[0]);
 	updateNaviBanner(naviCurrentStepIdx,null);
 	highlightNaviStep(naviCurrentStepIdx);
-	logDebug('[startDemo] RAF 登録直前');
-	demoRafId=requestAnimationFrame(demoTick);
-	logDebug('[startDemo] RAF 登録完了 → demoTick 待機中');
+	// fitBounds 後に RAF 開始：ズームアニメーション中の CSS transition 競合を防止する
+	goToMap();setTimeout(()=>{
+		map.fitBounds(L.latLngBounds(demoCoords),{padding:[40,40],animate:false});
+		// マーカーの CSS transition を無効化してカクつき・バウンスを防ぐ
+		const el=demoMarker&&demoMarker.getElement();
+		if(el){el.style.transition='none';el.style.webkitTransition='none';}
+		logDebug('[startDemo] RAF 登録直前');
+		demoRafId=requestAnimationFrame(demoTick);
+		logDebug('[startDemo] RAF 登録完了 → demoTick 待機中');
+	},100);
 }
 function demoTick(ts){
 	if(demoPaused||demoIdx>=demoCoords.length-1)return;
@@ -1218,7 +1223,7 @@ function demoTick(ts){
 		// ※ map.setView は呼ばない → 地図が車を追わず、車がルート上を視覚的に移動する
 		if(curPos){
 			demoMarker.setLatLng(curPos);
-			demoTrail.addLatLng(curPos);
+			// demoTrail は廃止（毎フレームのSVG再描画がRAFを低速化するため）
 			updateDemoProg();
 			if(naviActive)checkAndSpeak(curPos);
 		}


### PR DESCRIPTION
$(cat <<'EOF'
## 問題

PR #35 でデモ走行の自車マーカーが視覚的に動かない問題を修正したが、以下の問題が残存していた。

- **低速化**：自車がかなりゆっくりとしか動かない
- **前後バウンス**：自車が「進んで戻って」を繰り返す

## 根本原因

### 低速化の原因：`demoTrail.addLatLng(curPos)` による SVG 再描画

`demoTick` は毎フレーム（約60fps）`demoTrail.addLatLng(curPos)` を呼んでいた。Leaflet は SVG ポリラインにポイントを追加するたびに `<polyline points="...">` 属性を全座標分再生成する。デモ完走まで最大1600点以上のポリラインを60fpsで再描画し続けると、モバイル端末では RAF が著しく低速化する（数十秒 → 数分以上）。

### 前後バウンスの原因：RAF と fitBounds の CSS transition 競合

`fitBounds` によるズーム変更中に Leaflet が `leaflet-zoom-anim` CSS クラスをマップコンテナに適用し、マーカーに CSS transition が有効になる。この状態で RAF から `setLatLng` を60fps で連続呼び出すと、CSS transition がそれぞれの位置変化をアニメーションしようとして競合し、マーカーが視覚的に前後に揺れる。

## 修正内容

1. **`demoTrail`（軌跡ポリライン）を廃止**：毎フレームの SVG 再描画を完全に排除。ルートラインが既にルート全体を表示しているため、走行軌跡は不要。
2. **RAF の開始を `fitBounds` 完了後に移動**：`setTimeout` 内の `fitBounds` 呼び出し直後に RAF を開始することで、ズームアニメーション完了前に RAF が動き出す競合を防止。
3. **マーカーの CSS transition を明示的に無効化**：`fitBounds` 後に `el.style.transition = 'none'` を設定し、Leaflet が付与した transition の影響を排除。

## テスト

- [ ] デモ走行開始後、ルート全体が地図に表示される
- [ ] 自車マーカーが一定の速度でルート上を移動する（前後バウンスなし）
- [ ] デモが現実的な時間（数十秒〜1分程度）で完走する
- [ ] アプリ内ログに `[demoTick] 例外発生` が出ない

https://claude.ai/code/session_013doTe9VZ3ZDr3dBD4fJbs7
EOF
)