### PR TITLE
デモ走行中の自車位置を1秒間隔でログ出力する診断機能を追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -397,7 +397,7 @@ input[type="text"]:disabled{opacity:.4;cursor:not-allowed;}
 // ════════════════════════════════════════════════
 //  アプリバージョン
 // ════════════════════════════════════════════════
-const APP_VERSION='260412PR36';
+const APP_VERSION='260412PR37';
 document.getElementById('app-version').textContent=APP_VERSION;
 console.log(`[App] バージョン: ${APP_VERSION}`);
 
@@ -428,7 +428,7 @@ let gpsMarker=null,gpsAccCircle=null,watchId=null,isTracking=false,gpsLatLng=nul
 let useGpsAsStart=false;
 // デモ
 let demoCoords=[],demoIdx=0,demoRafId=null,demoPaused=true,demoSpeed=1,isDemoActive=false;
-let demoMarker=null,demoTrail=null,lastDemoTs=null,demoSteps=[];
+let demoMarker=null,demoTrail=null,lastDemoTs=null,demoSteps=[],demoLogIntervalId=null;
 let demoMilestone25=false,demoMilestone50=false,demoMilestone75=false; // デモ進捗マイルストーンフラグ
 let stepMarkers=[];  // 地図上のステップ番号マーカー
 // ログ
@@ -1191,6 +1191,13 @@ function startDemo(){
 		const el=demoMarker&&demoMarker.getElement();
 		if(el){el.style.transition='none';el.style.webkitTransition='none';}
 		logDebug('[startDemo] RAF 登録直前');
+		// 1秒ごとに自車位置をログ出力（デモ走行の動作診断用）
+		if(demoLogIntervalId){clearInterval(demoLogIntervalId);demoLogIntervalId=null;}
+		demoLogIntervalId=setInterval(()=>{
+			const pos=demoMarker?demoMarker.getLatLng():null;
+			const posStr=pos?`[${pos.lat.toFixed(5)},${pos.lng.toFixed(5)}]`:'null';
+			logDebug(`[demoPos] idx:${demoIdx}/${demoCoords.length-1} pos:${posStr} paused:${demoPaused} navi:${naviActive}`);
+		},1000);
 		demoRafId=requestAnimationFrame(demoTick);
 		logDebug('[startDemo] RAF 登録完了 → demoTick 待機中');
 	},100);
@@ -1262,6 +1269,7 @@ function pauseDemo(){console.log('[pauseDemo] デモ一時停止');demoPaused=tr
 function resumeDemo(){console.log('[resumeDemo] デモ再開');demoPaused=false;lastDemoTs=null;document.getElementById('demo-play-btn').textContent='⏸';demoRafId=requestAnimationFrame(demoTick);}
 function stopDemo(){
 	console.log('[stopDemo] デモ走行停止');
+	if(demoLogIntervalId){clearInterval(demoLogIntervalId);demoLogIntervalId=null;}
 	isDemoActive=false;
 	pauseDemo();naviActive=false;demoIdx=0;
 	demoMilestone25=false;demoMilestone50=false;demoMilestone75=false;


### PR DESCRIPTION
## 概要

PR #36 後も「数分に1回しか自車が移動しない」飛び飛び挙動が残存している。  
根本原因を特定するため、デモ走行中に自車位置を1秒間隔でログパネルへ出力する診断機能を追加した。

## 変更内容

- `demoLogIntervalId` 変数を追加（`setInterval` のID管理用）
- `startDemo()` 内でインターバルを開始：1秒ごとに `[demoPos]` ログを出力
- `stopDemo()` 内でインターバルをクリア
- `APP_VERSION` を `260412PR37` に更新

## ログ出力形式

```
[demoPos] idx:N/M pos:[lat,lng] paused:true/false navi:true/false
```

## 診断の読み方

| ログのパターン | 意味 |
|---|---|
| `idx` が毎秒増えない | `demoTick` の RAF が動いていない |
| `idx` は増えるが `pos` が変わらない | `demoMarker.setLatLng` の失敗 |
| `paused:true` になっている | `pauseDemo` が意図せず呼ばれている |
| `navi:false` になっている | `naviActive` が途中で false になっている |
| `idx` が突然大きく飛ぶ | dt が異常に大きい（数分間 RAF 停止後に再開） |

## テスト手順

1. デモ走行を開始する
2. ログタブを開く
3. 1秒ごとに `[demoPos]` ログが出力されることを確認する
4. 「数分後に移動」するときのログパターンを確認し、根本原因を特定する