### PR TITLE
highlightNaviStep の毎フレーム呼び出しを抑止してデモ走行のRAF停止問題を修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -397,7 +397,7 @@ input[type="text"]:disabled{opacity:.4;cursor:not-allowed;}
 // ════════════════════════════════════════════════
 //  アプリバージョン
 // ════════════════════════════════════════════════
-const APP_VERSION='260412PR37';
+const APP_VERSION='260412PR38';
 document.getElementById('app-version').textContent=APP_VERSION;
 console.log(`[App] バージョン: ${APP_VERSION}`);
 
@@ -440,6 +440,7 @@ let naviMuted=false;            // ミュート
 let naviSpoken={};              // 発話済み管理 {stepIdx_phase: true}
 let naviWatchId=null;           // GPS watch ID（案内用）
 let naviCurrentStepIdx=0;       // 現在のステップインデックス
+let lastHighlightedStep=-1;     // 直前にハイライトしたステップ（毎フレーム呼び出し抑止用）
 let naviRerouteTimer=null;      // リルートクールダウン
 let lastRerouteTime=0;
 let wakeLock=null;
@@ -1028,9 +1029,13 @@ function checkAndSpeak(curPos){
 		speak(makeVoiceText(step.type, step.modifier, step.name, dist, 'now'));
 	}
 
-	// バナー・ハイライトは必ず毎回更新
+	// バナーは距離が変わるため毎フレーム更新
 	updateNaviBanner(naviCurrentStepIdx, dist);
-	highlightNaviStep(naviCurrentStepIdx);
+	// ハイライトはステップが変化したときのみ更新（毎フレーム呼ぶと地図の repaint でRAFが停止するため）
+	if(naviCurrentStepIdx!==lastHighlightedStep){
+		lastHighlightedStep=naviCurrentStepIdx;
+		highlightNaviStep(naviCurrentStepIdx);
+	}
 }
 
 // 案内バナー更新
@@ -1162,7 +1167,7 @@ function startDemo(){
 	stopDemo();stopNavi();
 	isDemoActive=true;
 	// 案内状態を初期化
-	naviActive=true;naviSpoken={};naviCurrentStepIdx=0;naviApproaching=false;naviPrevDist=Infinity;naviMuted=false;
+	naviActive=true;naviSpoken={};naviCurrentStepIdx=0;lastHighlightedStep=-1;naviApproaching=false;naviPrevDist=Infinity;naviMuted=false;
 	document.getElementById('navi-mute-btn').textContent='🔊';
 	document.getElementById('navi-section').style.display='block';
 	document.getElementById('navi-bar').classList.add('visible');


### PR DESCRIPTION
## 概要

Issue #38 の修正。デモ走行中に地図タブを表示すると自車が数分間停止する問題を修正する。

## 原因

`checkAndSpeak()` が**毎フレーム** `highlightNaviStep()` を呼んでいた（旧コード行 1033）。  
`highlightNaviStep()` はステップマーカー全件の `style.opacity` / `style.background` 等を更新する。  
地図タブが表示状態（`display:flex`）のとき、この DOM 操作が大規模な repaint を引き起こし、RAF ループを数秒〜数分単位でブロックしていた。  
ログタブ表示中は地図が `display:none` のため repaint コストがほぼゼロとなり、RAF は動作していた（PR #37 の診断ログで確認済み）。

## 修正内容

- `lastHighlightedStep` 変数を追加
- `checkAndSpeak()` 内で `naviCurrentStepIdx` が前回から変化したときのみ `highlightNaviStep()` を呼ぶよう変更
- `startDemo()` で `lastHighlightedStep = -1` にリセット
- `APP_VERSION` を `260412PR38` に更新

## 変更前後

```javascript
// 変更前：毎フレーム呼ばれる
updateNaviBanner(naviCurrentStepIdx, dist);
highlightNaviStep(naviCurrentStepIdx);

// 変更後：ステップが変化したときのみ呼ぶ
updateNaviBanner(naviCurrentStepIdx, dist);
if(naviCurrentStepIdx!==lastHighlightedStep){
    lastHighlightedStep=naviCurrentStepIdx;
    highlightNaviStep(naviCurrentStepIdx);
}
```

## テスト手順

- デモ走行を開始し、**地図タブを表示したまま**自車が滑らかに移動するか確認する
- ログタブの `[demoPos]` で `idx` が毎秒増加していれば修正成功