### PR TITLE
fix: 地図/リストタブでデモ自車位置が更新されない不具合を修正 (#38)

### DIFF
--- a/index.html
+++ b/index.html
@@ -409,9 +409,9 @@ document.querySelectorAll('.tab').forEach(t=>t.addEventListener('click',()=>{
 	document.querySelectorAll('.view').forEach(x=>x.classList.remove('active'));
 	t.classList.add('active');
 	document.getElementById('view-'+t.dataset.view).classList.add('active');
-	if(t.dataset.view==='map') setTimeout(()=>map&&map.invalidateSize(),50);
+	if(t.dataset.view==='map') setTimeout(()=>map&&map.invalidateSize({animate:false}),50);
 }));
-function goToMap(){if(window.innerWidth<900){document.querySelectorAll('.tab').forEach(x=>x.classList.remove('active'));document.querySelectorAll('.view').forEach(x=>x.classList.remove('active'));document.querySelector('[data-view="map"]').classList.add('active');document.getElementById('view-map').classList.add('active');setTimeout(()=>map&&map.invalidateSize(),50);}}
+function goToMap(){if(window.innerWidth<900){document.querySelectorAll('.tab').forEach(x=>x.classList.remove('active'));document.querySelectorAll('.view').forEach(x=>x.classList.remove('active'));document.querySelector('[data-view="map"]').classList.add('active');document.getElementById('view-map').classList.add('active');setTimeout(()=>map&&map.invalidateSize({animate:false}),50);}}
 
 // ════════════════════════════════════════════════
 //  地図初期化
@@ -441,6 +441,7 @@ let naviSpoken={};              // 発話済み管理 {stepIdx_phase: true}
 let naviWatchId=null;           // GPS watch ID（案内用）
 let naviCurrentStepIdx=0;       // 現在のステップインデックス
 let lastHighlightedStep=-1;     // 直前にハイライトしたステップ（毎フレーム呼び出し抑止用）
+let lastBannerUpdateTime=0;     // バナー最終更新時刻（可視要素への repaint 抑止用）
 let naviRerouteTimer=null;      // リルートクールダウン
 let lastRerouteTime=0;
 let wakeLock=null;
@@ -1029,8 +1030,9 @@ function checkAndSpeak(curPos){
 		speak(makeVoiceText(step.type, step.modifier, step.name, dist, 'now'));
 	}
 
-	// バナーは距離が変わるため毎フレーム更新
-	updateNaviBanner(naviCurrentStepIdx, dist);
+	// バナーは約 300ms ごとに更新（可視 DOM への毎フレーム repaint を防ぐ）
+	const _bNow=performance.now();
+	if(_bNow-lastBannerUpdateTime>=300){lastBannerUpdateTime=_bNow;updateNaviBanner(naviCurrentStepIdx,dist);}
 	// ハイライトはステップが変化したときのみ更新（毎フレーム呼ぶと地図の repaint でRAFが停止するため）
 	if(naviCurrentStepIdx!==lastHighlightedStep){
 		lastHighlightedStep=naviCurrentStepIdx;


### PR DESCRIPTION
## 関連 Issue

Issue #38

## 概要

PR #37 の診断ログで「ログ画面では自車が進むが地図・リスト画面では進まない」現象を確認。
PR #39（`highlightNaviStep` 抑止）では悪化したため、今回 2 段階で修正。

### コミット 1（RAF → setInterval）

Android Chrome の `requestAnimationFrame` スロットリングが根本原因。
`setInterval(33ms)` に切り替えることで Chrome のアイドル最適化の影響を排除。

→ ログ画面での自車移動は復活したが、地図・リスト画面ではまだ動かない状態。

### コミット 2（今回追加）

**原因1: `updateNaviBanner` の毎フレーム可視 DOM 書き込み**

`checkAndSpeak()` から 33ms ごとに呼ばれる `updateNaviBanner()` が 6 つの `textContent` を書き換える。地図・リストタブ表示中は対象要素が可視状態のため毎フレーム repaint が発生し、レンダリングパイプラインがブロックされて自車位置の描画が止まっていた。ログタブでは 6 要素すべてが非表示のため repaint が起きず動いていた。

→ バナー更新を約 300ms スロットルに変更して repaint 頻度を大幅削減。

**原因2: `invalidateSize()` のアニメーション付き呼び出し**

地図タブ切り替え時に `{animate:false}` なしで `invalidateSize()` を呼ぶと Leaflet がマーカーパネルに CSS transition を付加し、`setLatLng` のたびにマーカーが前後に揺れて「振動」に見えていた。

→ `invalidateSize({animate:false})` に変更。

## 変更ファイル

- `index.html`
  - `APP_VERSION='260412PR40'`
  - `startDemo` / `pauseDemo` / `resumeDemo` / `demoTick`: RAF → setInterval
  - `checkAndSpeak`: `updateNaviBanner` を 300ms スロットルに変更
  - タブ切り替え・`goToMap`: `invalidateSize({animate:false})` に変更

## テスト項目（手動確認をお願いします）

- [ ] デモ走行を**地図タブ**で開始 → 自車がスムーズに進む（振動しない）
- [ ] デモ走行を**リストタブ**で表示 → 自車が進む
- [ ] デモ走行を**ログタブ**で表示 → 従来通り進む
- [ ] 地図タブに切り替えたとき → 自車が振動せず最新位置に表示される
- [ ] デモ一時停止・再開 → 正常に機能する
- [ ] デモ完走 → 正常に終了する